### PR TITLE
[INT-49] 문제 풀이 시간 변경 기능

### DIFF
--- a/src/components/pages/QuizPlay/QuizPlay.tsx
+++ b/src/components/pages/QuizPlay/QuizPlay.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from 'jotai';
+import { useAtom } from 'jotai/index';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -16,8 +17,9 @@ import * as styles from './QuizPlay.style';
 const QuizPlay = () => {
   const { openModal } = useModal();
   const navigate = useNavigate();
+  const [{ timeToSolveQuiz }] = useAtom(quizPlayStateAtom);
   const { leftSecond, isRunning, start, stop } = useTimer({
-    initTimeLimit: 3,
+    initTimeLimit: timeToSolveQuiz,
     startImmediately: true,
   });
 

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -24,6 +24,7 @@ const usePresetSetting = ({
 
   const handleTimeToSolveQuiz = (diff: number) => {
     const changeResult = timeToSolveQuiz + diff;
+    if (changeResult < 3 || changeResult > 99) return;
     setTimeToSolveQuiz(changeResult);
   };
 


### PR DESCRIPTION
## Github Issue 번호
#46 #47 #49
## 작업 내용
- 퀴즈 시작 전 설정 모달에서 카운터가 기존에 랜딩 시간을 조절하던 것을 문제 풀이 시간으로 조정
- 고정 값으로 받던 타이머 시간을 설정된 문제 풀이 시간으로 조정
## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
- [x] Jira 코드 리뷰 상태로 변경
