### PR TITLE
[INT-59] 나의 퀴즈 페이지 구현

### DIFF
--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -33,7 +33,7 @@ class QuizRepository {
     isPrivate,
     images,
     answers,
-    hashTagList
+    hashtagList,
   }: CreatePresetType) {
     const formData = new FormData();
     images.map((image) => formData.append('images', image));

--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -38,6 +38,7 @@ class QuizRepository {
     const formData = new FormData();
     images.map((image) => formData.append('images', image));
     answers.map((answer) => formData.append('answers', answer));
+    hashtagList.map((hashtag) => formData.append('hashtagList', hashtag));
     formData.append('title', title);
     formData.append('isPrivate', `${isPrivate}`);
 

--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -6,7 +6,7 @@ import {
   QuizPresetType,
 } from '@/types/quiz';
 
-import { deleteAsync, getAsync, postAsync } from './API';
+import { deleteAsync, getAsync, patchAsync, postAsync } from './API';
 
 class QuizRepository {
   static async getQuizByPinAsync(presetPin: string) {
@@ -46,6 +46,29 @@ class QuizRepository {
 
     const response = await postAsync<QuizPresetPinType, FormData>(
       '/quiz/create',
+      formData,
+    );
+    return response;
+  }
+
+  static async patchPresetAsync({
+    title,
+    isPrivate,
+    images,
+    answers,
+    hashtagList,
+    hintList,
+  }: CreatePresetType) {
+    const formData = new FormData();
+    images.map((image) => formData.append('images', image));
+    answers.map((answer) => formData.append('answers', answer));
+    hashtagList.map((hashtag) => formData.append('hashtagList', hashtag));
+    hintList.map((hint) => formData.append('hints', hint));
+    formData.append('title', title);
+    formData.append('isPrivate', `${isPrivate}`);
+
+    const response = await patchAsync<QuizPresetPinType, FormData>(
+      '/quiz/modify',
       formData,
     );
     return response;

--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -34,11 +34,13 @@ class QuizRepository {
     images,
     answers,
     hashtagList,
+    hintList,
   }: CreatePresetType) {
     const formData = new FormData();
     images.map((image) => formData.append('images', image));
     answers.map((answer) => formData.append('answers', answer));
     hashtagList.map((hashtag) => formData.append('hashtagList', hashtag));
+    hintList.map((hint) => formData.append('hints', hint));
     formData.append('title', title);
     formData.append('isPrivate', `${isPrivate}`);
 

--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -33,6 +33,7 @@ class QuizRepository {
     isPrivate,
     images,
     answers,
+    hashTags
   }: CreatePresetType) {
     const formData = new FormData();
     images.map((image) => formData.append('images', image));

--- a/src/apis/quiz.ts
+++ b/src/apis/quiz.ts
@@ -33,7 +33,7 @@ class QuizRepository {
     isPrivate,
     images,
     answers,
-    hashTags
+    hashTagList
   }: CreatePresetType) {
     const formData = new FormData();
     images.map((image) => formData.append('images', image));

--- a/src/components/common/Navigator/Navigator.style.ts
+++ b/src/components/common/Navigator/Navigator.style.ts
@@ -17,8 +17,8 @@ export const Wrapper = styled.nav`
   }}
 `;
 
-export const Section = styled.div<{ isSelected?: boolean }>`
-  ${({ theme, isSelected }) => {
+export const Section = styled.div<{ $isSelected?: boolean }>`
+  ${({ theme, $isSelected }) => {
     const { colors, fonts } = theme;
     return css`
       display: flex;
@@ -30,7 +30,7 @@ export const Section = styled.div<{ isSelected?: boolean }>`
       gap: 0.125rem 0;
 
       & > p {
-        color: ${isSelected ? colors.darkblue800 : colors.gray700};
+        color: ${$isSelected ? colors.darkblue800 : colors.gray700};
         font-size: ${fonts.deco4.fontFamily};
         font-size: 0.625rem;
         font-weight: ${fonts.deco4.fontFamily};
@@ -38,7 +38,7 @@ export const Section = styled.div<{ isSelected?: boolean }>`
       }
 
       & > svg {
-        color: ${isSelected ? colors.darkblue800 : colors.gray700};
+        color: ${$isSelected ? colors.darkblue800 : colors.gray700};
       }
     `;
   }}

--- a/src/components/common/Navigator/Navigator.style.ts
+++ b/src/components/common/Navigator/Navigator.style.ts
@@ -29,6 +29,8 @@ export const Section = styled.div<{ $isSelected?: boolean }>`
       width: 3.75rem;
       gap: 0.125rem 0;
 
+      cursor: pointer;
+
       & > p {
         color: ${$isSelected ? colors.darkblue800 : colors.gray700};
         font-size: ${fonts.deco4.fontFamily};

--- a/src/components/common/Navigator/Navigator.tsx
+++ b/src/components/common/Navigator/Navigator.tsx
@@ -13,7 +13,7 @@ const Navigator = () => {
   const matchHomeUrl = useMatch('/');
   const matchSearchUrl = useMatch('/search');
   const matchQuizGameUrl = useMatch('/quiz/*');
-  const matchCreateQuizUrl = useMatch('/create');
+  const matchMyQuizUrl = useMatch('/my-quiz');
 
   const { openModal } = useModal();
   const openGameSettingModal = () => openModal(<GameSettingModal />);
@@ -35,7 +35,7 @@ const Navigator = () => {
       </Link>
       {/** TODO : 나의 퀴즈 목록 페이지 개설 시 수정 필요 */}
       <Link to="/my-quiz">
-        <styles.Section isSelected={matchCreateQuizUrl !== null}>
+        <styles.Section isSelected={matchMyQuizUrl !== null}>
           <SmileIcon />
           <p>나의 퀴즈</p>
         </styles.Section>

--- a/src/components/common/Navigator/Navigator.tsx
+++ b/src/components/common/Navigator/Navigator.tsx
@@ -21,21 +21,21 @@ const Navigator = () => {
   return (
     <styles.Wrapper>
       <Link to="/">
-        <styles.Section isSelected={matchHomeUrl !== null}>
+        <styles.Section $isSelected={matchHomeUrl !== null}>
           <HomeIcon />
           <p>홈</p>
         </styles.Section>
       </Link>
       {/** TODO : 추후 퀴즈 목록 페이지 개설 시 추가 */}
       <Link to="/search">
-        <styles.Section isSelected={matchSearchUrl !== null}>
+        <styles.Section $isSelected={matchSearchUrl !== null}>
           <ZoomIcon />
           <p>퀴즈 검색</p>
         </styles.Section>
       </Link>
       {/** TODO : 나의 퀴즈 목록 페이지 개설 시 수정 필요 */}
       <Link to="/my-quiz">
-        <styles.Section isSelected={matchMyQuizUrl !== null}>
+        <styles.Section $isSelected={matchMyQuizUrl !== null}>
           <SmileIcon />
           <p>나의 퀴즈</p>
         </styles.Section>

--- a/src/components/common/Navigator/Navigator.tsx
+++ b/src/components/common/Navigator/Navigator.tsx
@@ -11,7 +11,7 @@ import * as styles from './Navigator.style';
 
 const Navigator = () => {
   const matchHomeUrl = useMatch('/');
-  const matchSearchUrl= useMatch('/search');
+  const matchSearchUrl = useMatch('/search');
   const matchQuizGameUrl = useMatch('/quiz/*');
   const matchCreateQuizUrl = useMatch('/create');
 
@@ -34,7 +34,7 @@ const Navigator = () => {
         </styles.Section>
       </Link>
       {/** TODO : 나의 퀴즈 목록 페이지 개설 시 수정 필요 */}
-      <Link to="/create">
+      <Link to="/my-quiz">
         <styles.Section isSelected={matchCreateQuizUrl !== null}>
           <SmileIcon />
           <p>나의 퀴즈</p>

--- a/src/components/main/AddQuizModal/AddQuizModal.style.ts
+++ b/src/components/main/AddQuizModal/AddQuizModal.style.ts
@@ -1,17 +1,26 @@
 import styled, { css } from 'styled-components';
 
-export const Section = styled.section`
-  ${({ theme }) => {
+export const Section = styled.section<{ $imageUrl?: string }>`
+  ${({ theme, $imageUrl }) => {
     return css`
       width: 22.5rem;
-      height: 50rem;
+      height: 100vh;
       position: relative;
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
       align-items: center;
       margin: auto;
       overflow-x: hidden;
       background-color: ${theme.colors.dark};
+
+      ${$imageUrl &&
+      css`
+        background-image: url(${$imageUrl});
+        background-size: auto 70%, cover;
+        background-position: 50% 0;
+        background-repeat: no-repeat;
+      `}
     `;
   }}
 `;
@@ -53,26 +62,29 @@ export const OptionBox = styled.div`
 `;
 
 export const UploadSection = styled.div`
-  ${({ theme }) => {
-    return css`
-      width: 22.5rem;
-      height: 28.13rem;
-    `;
-  }}
+  height: 60vh;
 `;
 
 export const UploadImage = styled.img`
   width: 100%;
   height: 100%;
+  object-fit: cover;
 `;
 export const UploadLinear = styled.div`
   width: 100%;
   height: 100%;
 `;
 export const AnswerSection = styled.div`
-  display: flex;
-  margin: 1.34rem;
-  flex-direction: column;
+  ${({ theme }) => {
+    return css`
+      width: 100%;
+      padding: 1.34rem;
+      display: flex;
+      flex-direction: column;
+      background-color: ${theme.colors.dark};
+      border-radius: 20px 20px 0px 0px;
+    `;
+  }}
 `;
 
 export const NormalText = styled.span`

--- a/src/components/main/AddQuizModal/AddQuizModal.style.ts
+++ b/src/components/main/AddQuizModal/AddQuizModal.style.ts
@@ -4,7 +4,7 @@ export const Section = styled.section<{ $imageUrl?: string }>`
   ${({ theme, $imageUrl }) => {
     return css`
       width: 22.5rem;
-      height: 100vh;
+      height: 100%;
       position: relative;
       display: flex;
       flex-direction: column;

--- a/src/components/main/AddQuizModal/AddQuizModal.style.ts
+++ b/src/components/main/AddQuizModal/AddQuizModal.style.ts
@@ -13,7 +13,7 @@ export const Section = styled.section`
       overflow-x: hidden;
       background-color: ${theme.colors.dark};
     `;
-  }}?
+  }}
 `;
 
 export const ButtonWrapper = styled.button`

--- a/src/components/main/AddQuizModal/AddQuizModal.tsx
+++ b/src/components/main/AddQuizModal/AddQuizModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import useModal from '@/hooks/useModal';
@@ -63,6 +63,7 @@ const AddQuizModal = ({
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
       setQuizData((prev) => ({ ...prev, image: null, imageUrl: '' }));
+      closeModal();
     }
   };
 
@@ -76,18 +77,8 @@ const AddQuizModal = ({
     closeModal();
   };
 
-  // 제출 완료용 버튼 Components
-  const SubmitQuizButton = useCallback(
-    () => (
-      <styles.SubmitButton onClick={verifySubmitQuiz}>
-        저장하기
-      </styles.SubmitButton>
-    ),
-    [quizData],
-  );
-
   return (
-    <styles.Section>
+    <styles.Section $imageUrl={quizData.imageUrl}>
       <input
         ref={fileInputRef}
         type="file"
@@ -101,13 +92,10 @@ const AddQuizModal = ({
         <styles.SettingButton onClick={removeUploadedFile}>
           삭제
         </styles.SettingButton>
+        <styles.SettingButton onClick={closeModal}>닫기</styles.SettingButton>
       </styles.ButtonWrapper>
 
-      <styles.UploadSection>
-        {quizData.imageUrl && (
-          <styles.UploadImage src={quizData.imageUrl} alt="image" />
-        )}
-      </styles.UploadSection>
+      <styles.UploadSection></styles.UploadSection>
       <styles.AnswerSection>
         <styles.NormalText>
           위 사진에 대해서 <styles.PointText>설명</styles.PointText>해주세요.
@@ -130,7 +118,9 @@ const AddQuizModal = ({
         </styles.OptionBox>
         <styles.InfoText>문제를 풀 때 힌트로 쓸 수 있어요</styles.InfoText>
       </styles.AnswerSection>
-      <SubmitQuizButton />
+      <styles.SubmitButton onClick={verifySubmitQuiz}>
+        저장하기
+      </styles.SubmitButton>
     </styles.Section>
   );
 };

--- a/src/components/main/AddQuizModal/AddQuizModal.tsx
+++ b/src/components/main/AddQuizModal/AddQuizModal.tsx
@@ -16,6 +16,13 @@ interface AddQuizModalProps {
   initialData?: CreateQuizWithUrlType;
 }
 
+type QuizInitType = {
+  image: null;
+  answer: string;
+  imageUrl: string;
+  hint: string;
+};
+
 const AddQuizModal = ({
   updateQuiz,
   index,
@@ -23,9 +30,9 @@ const AddQuizModal = ({
 }: AddQuizModalProps) => {
   const { closeModal } = useModal();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [quizData, setQuizData] = useState<CreateQuizWithUrlType>(
-    initialData || { image: null, answer: '', imageUrl: '', hint: '' },
-  );
+  const [quizData, setQuizData] = useState<
+    CreateQuizWithUrlType | QuizInitType
+  >(initialData || { image: null, answer: '', imageUrl: '', hint: '' });
   const openFileUploadDialog = () => fileInputRef.current?.click();
 
   useEffect(() => {
@@ -68,7 +75,7 @@ const AddQuizModal = ({
   };
 
   const verifySubmitQuiz = () => {
-    const { image, answer, imageUrl, hint } = quizData;
+    const { image, answer, imageUrl } = quizData;
     if (!image || !answer || !imageUrl) {
       toast.error('이미지, 정답 모두 업로드 해야 합니다!');
       return;

--- a/src/components/main/CategoryCarousel/CategoryCarousel.tsx
+++ b/src/components/main/CategoryCarousel/CategoryCarousel.tsx
@@ -28,13 +28,13 @@ const CategoryCarousel = () => {
       <styles.Carousel>
         {presetList &&
           presetList.map((preset) => {
-            const { title, thumbnailUrl, hashtagList, presetPin } = preset;
+          const { title, thumbnailUrl, hashTagList, presetPin } = preset;
             return (
               <PresetCard
                 key={presetPin}
                 title={title}
                 thumbnailUrl={thumbnailUrl}
-                hashtagList={hashtagList}
+                hashTagList={hashTagList}
                 handleClick={() => handleCardClick(preset)}
               />
             );
@@ -43,13 +43,13 @@ const CategoryCarousel = () => {
       <styles.CarouselClone>
         {presetList &&
           presetList.map((preset) => {
-            const { title, thumbnailUrl, hashtagList, presetPin } = preset;
+            const { title, thumbnailUrl, hashTagList, presetPin } = preset;
             return (
               <PresetCard
                 key={presetPin}
                 title={title}
                 thumbnailUrl={thumbnailUrl}
-                hashtagList={hashtagList}
+                hashTagList={hashTagList}
                 handleClick={() => handleCardClick(preset)}
               />
             );

--- a/src/components/main/CategoryCarousel/CategoryCarousel.tsx
+++ b/src/components/main/CategoryCarousel/CategoryCarousel.tsx
@@ -28,13 +28,13 @@ const CategoryCarousel = () => {
       <styles.Carousel>
         {presetList &&
           presetList.map((preset) => {
-          const { title, thumbnailUrl, hashTagList, presetPin } = preset;
+            const { title, thumbnailUrl, hashtagList, presetPin } = preset;
             return (
               <PresetCard
                 key={presetPin}
                 title={title}
                 thumbnailUrl={thumbnailUrl}
-                hashTagList={hashTagList}
+                hashtagList={hashtagList}
                 handleClick={() => handleCardClick(preset)}
               />
             );
@@ -43,13 +43,13 @@ const CategoryCarousel = () => {
       <styles.CarouselClone>
         {presetList &&
           presetList.map((preset) => {
-            const { title, thumbnailUrl, hashTagList, presetPin } = preset;
+            const { title, thumbnailUrl, hashtagList, presetPin } = preset;
             return (
               <PresetCard
                 key={presetPin}
                 title={title}
                 thumbnailUrl={thumbnailUrl}
-                hashTagList={hashTagList}
+                hashtagList={hashtagList}
                 handleClick={() => handleCardClick(preset)}
               />
             );

--- a/src/components/main/CategoryCarousel/CategoryCarouselImage.tsx
+++ b/src/components/main/CategoryCarousel/CategoryCarouselImage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import useModal from '@/hooks/useModal';
 import { QuizPresetType } from '@/types/quiz';
 
@@ -10,7 +8,7 @@ const CategoryCarouselImage = ({
   thumbnailUrl,
   presetPin,
   title,
-  hashTagList,
+  hashtagList,
 }: QuizPresetType) => {
   const { openModal } = useModal();
 
@@ -37,7 +35,7 @@ const CategoryCarouselImage = ({
         />
         <styles.TitleText>{title}</styles.TitleText>
         <styles.HashtagWrapper>
-          {hashTagList?.slice(0, 2).map((hashtag) => (
+          {hashtagList?.slice(0, 2).map((hashtag) => (
             <styles.HashtagText>{hashtag}</styles.HashtagText>
           ))}
         </styles.HashtagWrapper>

--- a/src/components/main/CategoryCarousel/CategoryCarouselImage.tsx
+++ b/src/components/main/CategoryCarousel/CategoryCarouselImage.tsx
@@ -10,7 +10,7 @@ const CategoryCarouselImage = ({
   thumbnailUrl,
   presetPin,
   title,
-  hashtagList,
+  hashTagList,
 }: QuizPresetType) => {
   const { openModal } = useModal();
 
@@ -37,7 +37,7 @@ const CategoryCarouselImage = ({
         />
         <styles.TitleText>{title}</styles.TitleText>
         <styles.HashtagWrapper>
-          {hashtagList?.slice(0, 2).map((hashtag) => (
+          {hashTagList?.slice(0, 2).map((hashtag) => (
             <styles.HashtagText>{hashtag}</styles.HashtagText>
           ))}
         </styles.HashtagWrapper>

--- a/src/components/main/CreateQuizImageView/CreateQuizImage.style.ts
+++ b/src/components/main/CreateQuizImageView/CreateQuizImage.style.ts
@@ -10,7 +10,9 @@ export const CreateQuizWrapper = styled.div<{ image: string }>`
       border-radius: 0.75rem;
       border: 1px solid #fff;
       box-shadow: 0px 0px 4px 0px #a1db00;
-      background-image: url(${image});
+
+      background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+        url(${image});
       background-repeat: no-repeat;
       background-position: center;
       background-size: cover;

--- a/src/components/main/CreateQuizImageView/CreateQuizImage.tsx
+++ b/src/components/main/CreateQuizImageView/CreateQuizImage.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-
 import * as styles from './CreateQuizImage.style';
 
 interface CreateQuizImageType {
-  index: number
+  index: number;
   url: string;
   answer?: string;
   hint?: string;

--- a/src/components/main/GameSettingModal/GameSettingModal.tsx
+++ b/src/components/main/GameSettingModal/GameSettingModal.tsx
@@ -4,11 +4,14 @@ import { ReactComponent as MuteIcon } from '@/assets/icons/muteIcon.svg';
 import { ReactComponent as SoundIcon } from '@/assets/icons/soundIcon.svg';
 import Modal from '@/components/common/modal';
 import useModal from '@/hooks/useModal';
+import useVolumeControl from '@/hooks/useVolumeControl';
 
 import * as styles from './GameSettingModal.style';
 
 const GameSettingModal = () => {
   const { closeModal } = useModal();
+  const { volume } = useVolumeControl();
+
   return (
     <Modal>
       <Modal.MainContent>
@@ -17,8 +20,16 @@ const GameSettingModal = () => {
           <styles.SettingBox>
             <h5>사운드</h5>
             <styles.SoundOptionBox>
-              <SoundOptionBox title="배경음" value={100} />
-              <SoundOptionBox title="효과음" value={80} />
+              <SoundOptionBox
+                title="배경음"
+                value={volume.backgroundVolume}
+                id="backgroundVolume"
+              />
+              <SoundOptionBox
+                title="효과음"
+                value={volume.soundEffectVolume}
+                id="soundEffectVolume"
+              />
             </styles.SoundOptionBox>
           </styles.SettingBox>
         </styles.Wrapper>
@@ -36,13 +47,23 @@ const GameSettingModal = () => {
 
 export default GameSettingModal;
 
+type SoundOptionType = 'backgroundVolume' | 'soundEffectVolume';
 interface SoundOptionBoxProps {
+  id: SoundOptionType;
   title: string;
   value: number;
 }
 
-const SoundOptionBox = ({ title, value }: SoundOptionBoxProps) => {
-  const [volume, setVolume] = useState(value);
+const SoundOptionBox = ({ id, title, value }: SoundOptionBoxProps) => {
+  const [volume, setVolume] = useState(value * 100);
+  const { onChange } = useVolumeControl();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setVolume(Number(value));
+    onChange({ [id]: Number(value) / 100 });
+  };
+
   return (
     <styles.SoundOptionBox>
       <styles.SoundOptionRow>
@@ -56,7 +77,7 @@ const SoundOptionBox = ({ title, value }: SoundOptionBoxProps) => {
         <input
           type="range"
           defaultValue={volume}
-          onChange={(event) => setVolume(Number(event.target.value))}
+          onChange={handleChange}
           min="0"
           max="100"
         />

--- a/src/components/main/GameStartModal/GameStartModal.style.ts
+++ b/src/components/main/GameStartModal/GameStartModal.style.ts
@@ -73,7 +73,7 @@ export const ThumbnailSection = styled.div<{ $thumbnailUrl: string }>`
 
       background-color: ${theme.colors.white};
       background: ${$thumbnailUrl
-        ? `url(${$thumbnailUrl})`
+        ? `center center url(${$thumbnailUrl})`
         : theme.colors.gray800};
       background-size: cover;
 

--- a/src/components/main/GameStartModal/GameStartModal.style.ts
+++ b/src/components/main/GameStartModal/GameStartModal.style.ts
@@ -10,11 +10,13 @@ export const Title = styled.span`
 
       color: ${theme.colors.darkblue300};
       text-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+      text-align: center;
       font-family: ${theme.fonts.deco3.fontFamily};
       font-size: 1.875rem;
       font-style: normal;
       font-weight: 400;
-      line-height: normal;
+      line-height: 125%;
+      word-break: keep-all;
 
       background: rgba(0, 0, 0, 0.6);
     `;

--- a/src/components/main/JoinPresetModal/JoinPresetModal.tsx
+++ b/src/components/main/JoinPresetModal/JoinPresetModal.tsx
@@ -34,7 +34,7 @@ const JoinPresetModal = () => {
         <styles.Wrapper>
           <h4>핀 입력</h4>
           <styles.SettingBox>
-            <span>플레이할 퀴즈 핀 번호를 입력해 주세요.</span>
+            <span>플레이할 퀴즈 프리셋 핀 번호를 입력해 주세요.</span>
             <styles.PrivatePinInput
               value={presetPin}
               onChange={handleAnswerInput}

--- a/src/components/main/ModifyPresetImageView/ModifyPresetImageView.style.ts
+++ b/src/components/main/ModifyPresetImageView/ModifyPresetImageView.style.ts
@@ -1,0 +1,83 @@
+import { css, styled } from 'styled-components';
+
+export const ModifyPresetWrapper = styled.div<{ image: string }>`
+  ${({ image }) => {
+    return css`
+      position: relative;
+      width: 8.125rem;
+      height: 11.25rem;
+      padding: 0;
+      border-radius: 0.75rem;
+      border: 1px solid #fff;
+      box-shadow: 0px 0px 4px 0px #a1db00;
+
+      background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+        url(${image});
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: cover;
+    `;
+  }}
+`;
+export const QuizModifyWrapper = styled.div`
+  display: none;
+  position: absolute;
+  margin: -0.0625rem;
+  padding: 0;
+  width: 8.125rem;
+  height: 11.25rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.12rem;
+
+  border-radius: 0.75rem;
+  background: rgba(20, 21, 20, 0.6);
+  ${ModifyPresetWrapper}:hover & {
+    display: flex;
+  }
+`;
+export const ModifyButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      display: flex;
+      padding: 0.625rem 1.25rem;
+      justify-content: center;
+      align-items: center;
+      gap: 0.625rem;
+
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.caption.fontFamily};
+      font-weight: ${theme.fonts.caption.fontWeight};
+      font-size: 0.625rem;
+      border-radius: 1.5625rem;
+      border: 1px solid #fff;
+      box-shadow: 0px 0px 8px 0px #fff;
+    `;
+  }}
+`;
+
+export const PresetNameText = styled.p`
+  ${({ theme }) => {
+    return css`
+      margin-top: 9rem;
+      margin-left: 0.62rem;
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: 0.75rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+    `;
+  }}
+`;
+
+export const HashTagText = styled.p`
+  ${({ theme }) => {
+    return css`
+      margin-left: 0.62rem;
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.caption.fontFamily};
+      font-size: 0.625rem;
+      font-weight: ${theme.fonts.caption.fontWeight};
+    `;
+  }}
+`;

--- a/src/components/main/ModifyPresetImageView/ModifyPresetImageView.tsx
+++ b/src/components/main/ModifyPresetImageView/ModifyPresetImageView.tsx
@@ -1,0 +1,37 @@
+import * as styles from './ModifyPresetImageView.style';
+
+interface ModifyPresetImageViewType {
+  index: number;
+  url: string;
+  title?: string;
+  startQuiz: (index: number) => void;
+  removeQuiz: (index: number) => void;
+  modifyQuiz: (index: number) => void;
+}
+const ModifyPresetImageView = ({
+  index,
+  url,
+  title,
+  startQuiz,
+  removeQuiz,
+  modifyQuiz,
+}: ModifyPresetImageViewType) => {
+  return (
+    <styles.ModifyPresetWrapper image={url}>
+      <styles.QuizModifyWrapper>
+        <styles.ModifyButton onClick={() => startQuiz(index)}>
+          시작하기
+        </styles.ModifyButton>
+        <styles.ModifyButton onClick={() => modifyQuiz(index)}>
+          수정하기
+        </styles.ModifyButton>
+        <styles.ModifyButton onClick={() => removeQuiz(index)}>
+          삭제하기
+        </styles.ModifyButton>
+      </styles.QuizModifyWrapper>
+      <styles.PresetNameText>{title}</styles.PresetNameText>
+    </styles.ModifyPresetWrapper>
+  );
+};
+
+export default ModifyPresetImageView;

--- a/src/components/main/ModifyPresetImageView/index.ts
+++ b/src/components/main/ModifyPresetImageView/index.ts
@@ -1,0 +1,3 @@
+import ModifyPresetImageView from './ModifyPresetImageView';
+
+export default ModifyPresetImageView;

--- a/src/components/main/PresetCard/PresetCard.tsx
+++ b/src/components/main/PresetCard/PresetCard.tsx
@@ -5,14 +5,14 @@ import * as styles from './PresetCard.style.ts';
 export interface QuizPresetTemplateType {
   title: string;
   thumbnailUrl: string;
-  hashTagList?: string[];
+  hashtagList?: string[];
   handleClick: React.MouseEventHandler<HTMLDivElement>;
 }
 
 const PresetCard = ({
   title,
   thumbnailUrl,
-  hashTagList,
+  hashtagList,
   handleClick,
 }: QuizPresetTemplateType) => {
   return (
@@ -20,7 +20,7 @@ const PresetCard = ({
       <styles.TitleText>{title}</styles.TitleText>
       <styles.Image imageurl={thumbnailUrl} />
       <styles.HashtagWrapper>
-        {hashTagList?.slice(0, 2).map((hashtag) => (
+        {hashtagList?.slice(0, 2).map((hashtag) => (
           <styles.HashtagText>{hashtag}</styles.HashtagText>
         ))}
       </styles.HashtagWrapper>

--- a/src/components/main/PresetCard/PresetCard.tsx
+++ b/src/components/main/PresetCard/PresetCard.tsx
@@ -5,14 +5,14 @@ import * as styles from './PresetCard.style.ts';
 export interface QuizPresetTemplateType {
   title: string;
   thumbnailUrl: string;
-  hashtagList?: string[];
+  hashTagList?: string[];
   handleClick: React.MouseEventHandler<HTMLDivElement>;
 }
 
 const PresetCard = ({
   title,
   thumbnailUrl,
-  hashtagList,
+  hashTagList,
   handleClick,
 }: QuizPresetTemplateType) => {
   return (
@@ -20,7 +20,7 @@ const PresetCard = ({
       <styles.TitleText>{title}</styles.TitleText>
       <styles.Image imageurl={thumbnailUrl} />
       <styles.HashtagWrapper>
-        {hashtagList?.slice(0, 2).map((hashtag) => (
+        {hashTagList?.slice(0, 2).map((hashtag) => (
           <styles.HashtagText>{hashtag}</styles.HashtagText>
         ))}
       </styles.HashtagWrapper>

--- a/src/components/main/QuizForm/QuizForm.style.ts
+++ b/src/components/main/QuizForm/QuizForm.style.ts
@@ -1,0 +1,182 @@
+import styled, { css } from 'styled-components';
+
+export const CreateQuizWrapper = styled.div`
+  margin: 1rem;
+  gap: 0.5rem;
+
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.title.fontFamily};
+      font-size: ${theme.fonts.title.fontSize}rem;
+      font-weight: ${theme.fonts.title.fontWeight};
+      line-height: ${theme.fonts.title.lineHeight};
+      text-align: center;
+    `;
+  }}
+`;
+
+export const PointTitle = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+
+export const GetPresetButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      margin-left: auto;
+      margin-top: 1rem;
+      padding: 0.6rem 1rem;
+
+      border-radius: 1.5625rem;
+      border: 1px solid ${theme.colors.white};
+
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: ${theme.fonts.body2R.fontSize}rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+    `;
+  }}
+`;
+
+export const PrivateWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+  padding: 0.38rem;
+`;
+
+export const NameLabelWrapper = styled.span`
+  display: flex;
+  flex-direction: column;
+  gap: 0.88rem;
+`;
+
+export const NameLabel = styled.label`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.darkblue200};
+      font-family: ${theme.fonts.subtitle2B.fontFamily};
+      font-size: ${theme.fonts.subtitle2B.fontSize}rem;
+      font-weight: ${theme.fonts.subtitle2B.fontWeight};
+    `;
+  }}
+`;
+
+export const InfoLabel = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body3.fontFamily};
+      font-size: ${theme.fonts.body3.fontSize}rem;
+      font-weight: ${theme.fonts.body3.fontWeight};
+    `;
+  }}
+`;
+
+export const CountLabel = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2B.fontFamily};
+      font-size: ${theme.fonts.body2B.fontSize}rem;
+      font-weight: ${theme.fonts.body2B.fontWeight};
+      line-height: ${theme.fonts.body2B.lineHeight};
+    `;
+  }}
+`;
+
+export const NameInput = styled.input`
+  ${({ theme }) => {
+    return css`
+      height: 2rem;
+      padding: 0.5rem;
+      border: 1px solid ${theme.colors.white};
+      border-radius: 0.5rem;
+
+      font-family: ${theme.fonts.body3.fontFamily};
+      font-size: ${theme.fonts.body3.fontSize}rem;
+      font-weight: ${theme.fonts.body3.fontWeight};
+      line-height: ${theme.fonts.body3.lineHeight};
+      color: ${theme.colors.white};
+      background-color: transparent;
+
+      &::placeholder {
+        color: ${theme.colors.black};
+      }
+    `;
+  }}
+`;
+
+export const QuizListWrapper = styled.section`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.62rem;
+  margin: 0 1.06rem;
+  justify-content: space-between;
+`;
+export const AddQuizWrapper = styled.div`
+  display: flex;
+  width: 8.125rem;
+  height: 11.25rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.62rem;
+  border-radius: 1rem;
+  border: 1px solid #fff;
+`;
+export const UploadQuizButton = styled.div`
+  ${({ theme }) => {
+    return css`
+      width: 6.5rem;
+      height: 1.5rem;
+      justify-content: center;
+      align-items: center;
+
+      text-align: center;
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: ${theme.fonts.body2R.fontSize}rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+      line-height: ${theme.fonts.body2R.lineHeight};
+      color: ${theme.colors.white};
+      border-radius: 1.5rem;
+      border: 1px solid #fff;
+    `;
+  }}
+`;
+
+export const AddNewQuizButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      width: 10rem;
+      height: 2rem;
+      margin: 2rem auto;
+
+      border-radius: 1.5rem;
+      border: 1px solid ${theme.colors.darkblue400};
+      text-align: center;
+
+      font-family: ${theme.fonts.body2B.fontFamily};
+      font-size: ${theme.fonts.body2B.fontSize}rem;
+      font-weight: ${theme.fonts.body2B.fontWeight};
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+export const UploadText = styled.img``;
+export const ArrowIcon = styled.img``;

--- a/src/components/main/QuizForm/QuizForm.tsx
+++ b/src/components/main/QuizForm/QuizForm.tsx
@@ -1,0 +1,234 @@
+import { useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+import QuizRepository from '@/apis/quiz';
+import AddQuizModal from '@/components/main/AddQuizModal';
+import CreateQuizImage from '@/components/main/CreateQuizImageView';
+import HashtagInput from '@/components/main/HastagInput';
+import ToggleButton from '@/components/main/ToggleButton/ToggleButton';
+import useModal from '@/hooks/useModal';
+import { createdQuizPresetAtomWithLocalStorage } from '@/stores/quiz';
+import { theme } from '@/styles/theme';
+import { CreateQuizWithUrlType, GetQuizListOutput, QuizPresetType, QuizType } from '@/types/quiz';
+
+import * as styles from './QuizForm.style';
+
+interface QuizFormProps {
+  presetPin?: string;
+  originData?: GetQuizListOutput;
+}
+
+const convertURLtoFile = async (url: string) => {
+  const response = await fetch(url);
+  const data = await response.blob();
+  const ext = url.split(".").pop(); // url 구조에 맞게 수정할 것
+  const filename = url.split("/").pop() ?? 'noname'; // url 구조에 맞게 수정할 것
+  const metadata = { type: `image/${ext}` };
+  return new File([data], filename, metadata);
+};
+
+const convertQuizList = (quizList: QuizType[]) => {
+  return Promise.all(quizList.map(quiz => convertURLtoFile(quiz.imageUrl).then(imageFile => {
+    return {
+      hint: '',
+      image: imageFile,
+      answer: quiz.answer,
+      imageUrl: quiz.imageUrl,
+    };
+  })))
+}
+
+const QuizForm = ({ originData }: QuizFormProps) => {
+  const { openModal } = useModal();
+  const navigate = useNavigate();
+  const [presetData, setPresetData] = useState<QuizPresetType>(
+    {
+      isPrivate: originData?.isPrivate ?? false,
+      title: originData?.title ?? '',
+      presetPin: originData?.presetPin ?? '',
+      thumbnailUrl: originData?.thumbnailUrl ?? '',
+      hashtagList: originData?.hashtagList ?? []
+    },
+  );
+
+
+  const [quizList, setQuizList] = useState<CreateQuizWithUrlType[]>([]);
+  const setCreatedPreset = useSetAtom(createdQuizPresetAtomWithLocalStorage);
+
+  const updateQuiz = (data: CreateQuizWithUrlType, index: number) => {
+    const newQuizList = [...quizList];
+    newQuizList[index] = data;
+    setQuizList(newQuizList);
+  };
+
+  const openAddQuizModal = () => {
+    openModal(<AddQuizModal updateQuiz={updateQuiz} index={quizList.length} />);
+  };
+
+  const modifyCurrentQuiz = (index: number) => {
+    openModal(
+      <AddQuizModal
+        updateQuiz={updateQuiz}
+        index={index}
+        initialData={quizList[index]}
+      />,
+    );
+  };
+
+  const removeCurrentQuiz = (index: number) => {
+    if (window.confirm('정말 삭제하시겠습니까?')) {
+      setQuizList((prev) => [
+        ...prev.slice(0, index),
+        ...prev.slice(index + 1),
+      ]);
+    }
+  };
+
+  const handleTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const title = event.target.value;
+    if (title.length > 50) {
+      toast.error('퀴즈 프리셋 제목은 50글자 이상 지정할 수 없습니다. ');
+      return;
+    }
+    setPresetData((prev) => ({ ...prev, title: event.target.value }));
+  };
+
+  const handleToggle = (status: boolean) => {
+    setPresetData((prev) => ({ ...prev, isPrivate: status }));
+  };
+
+  const handleHashtag = (hashtagList: string[]) => {
+    setPresetData((prev) => ({
+      ...prev,
+      hashtagList,
+    }));
+  };
+
+  const savePresetData = async (presetPin: string) => {
+    const { isPrivate, thumbnailUrl, title } =
+      await QuizRepository.getQuizByPinAsync(presetPin);
+    setCreatedPreset({
+      type: 'MODIFY',
+      item: { presetPin, isPrivate, thumbnailUrl, title },
+    });
+  };
+
+  const submitQuizData = async () => {
+    const { hashtagList, title, isPrivate } = presetData;
+    const images = quizList.map((value) => value.image);
+    const answers = quizList.map((value) => value.answer);
+
+    const isEmpty = !answers.length || !images.length;
+    const isNotSame = answers.length !== images.length;
+
+    if (!isEmpty && isNotSame) {
+      toast.error('최소 1개 이상의 퀴즈를 등록해야 합니다.');
+      return;
+    }
+
+    if (!title) {
+      toast.error('퀴즈 프리셋 이름은 반드시 등록해야 합니다.');
+      return;
+    }
+
+    try {
+      const { presetPin } = await QuizRepository.postCreateNewPresetAsync({
+        answers,
+        images,
+        title,
+        isPrivate,
+        hashTags: hashtagList ?? []
+      });
+
+      savePresetData(presetPin);
+      navigate(-1);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    if(originData){
+      (async () => {
+        const list = await convertQuizList(originData.quizList);
+        setQuizList(list);
+      })();
+    }
+  }, [originData]);
+
+  return (
+    <>
+      <styles.NameLabelWrapper>
+        <styles.InputWrapper>
+          <styles.NameLabel>
+            퀴즈 프리셋 이름 <styles.InfoLabel>(최대 50글자)</styles.InfoLabel>
+          </styles.NameLabel>
+          <styles.NameInput
+            onChange={handleTitle}
+            value={presetData.title}
+          ></styles.NameInput>
+        </styles.InputWrapper>
+
+        <styles.InputWrapper>
+          <styles.PrivateWrapper>
+            <styles.NameLabel>퀴즈 프리셋 비공개</styles.NameLabel>
+            <ToggleButton
+              onColor={theme.colors.darkblue400}
+              offColor={theme.colors.gray400}
+              toggleState={handleToggle}
+            />
+          </styles.PrivateWrapper>
+          <styles.InfoLabel>
+            (친구들끼리 플레이를 원한다면 비공개를 설정하세요)
+          </styles.InfoLabel>
+        </styles.InputWrapper>
+
+        <styles.InputWrapper>
+          <styles.NameLabel>해시태그</styles.NameLabel>
+          <styles.InfoLabel>
+            (퀴즈를 나타낼 수 있는 해시태그를 만들어주세요)
+          </styles.InfoLabel>
+          <HashtagInput
+            hashtag={presetData.hashtagList ?? []}
+            setHashtag={handleHashtag}
+          />
+        </styles.InputWrapper>
+      </styles.NameLabelWrapper>
+
+      <div>
+        <styles.NameLabel>출제 문항</styles.NameLabel>
+        <styles.CountLabel> ( {quizList.length} ) </styles.CountLabel>
+      </div>
+      <styles.QuizListWrapper>
+        {quizList &&
+          quizList.map((quiz, index) => (
+            <CreateQuizImage
+              key={index}
+              index={index}
+              answer={quiz.answer}
+              url={quiz.imageUrl}
+              hint={quiz.hint}
+              removeQuiz={removeCurrentQuiz}
+              modifyQuiz={modifyCurrentQuiz}
+            />
+          ))}
+        {quizList.length < 10 && (
+          <styles.AddQuizWrapper>
+            <styles.UploadText src="/src/assets/images/uploadQuizText.svg" />
+            <styles.ArrowIcon src="/src/assets/icons/arrowIcon.svg" />
+            <styles.UploadQuizButton onClick={openAddQuizModal}>
+              추가하기
+            </styles.UploadQuizButton>
+          </styles.AddQuizWrapper>
+        )}
+      </styles.QuizListWrapper>
+      <styles.AddNewQuizButton onClick={submitQuizData}>
+        퀴즈 수정하기
+      </styles.AddNewQuizButton>
+    </>
+  );
+};
+
+export default QuizForm;

--- a/src/components/main/QuizForm/QuizForm.tsx
+++ b/src/components/main/QuizForm/QuizForm.tsx
@@ -39,7 +39,7 @@ const convertQuizList = (quizList: QuizType[]) => {
     quizList.map((quiz) =>
       convertURLtoFile(quiz.imageUrl).then((imageFile) => {
         return {
-          hint: '',
+          hint: quiz.hint,
           image: imageFile,
           answer: quiz.answer,
           imageUrl: quiz.imageUrl,
@@ -122,9 +122,10 @@ const QuizForm = ({ originData }: QuizFormProps) => {
   };
 
   const submitQuizData = async () => {
-    const { hashtagList: hashtagList, title, isPrivate } = presetData;
+    const { hashtagList, title, isPrivate } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
+    const hints = quizList.map((value) => value.hint);
 
     const isEmpty = !answers.length || !images.length;
     const isNotSame = answers.length !== images.length;
@@ -140,12 +141,13 @@ const QuizForm = ({ originData }: QuizFormProps) => {
     }
 
     try {
-      const { presetPin } = await QuizRepository.postCreateNewPresetAsync({
+      const { presetPin } = await QuizRepository.patchPresetAsync({
         answers,
         images,
         title,
         isPrivate,
         hashtagList: hashtagList ?? [],
+        hintList: hints,
       });
 
       savePresetData(presetPin);

--- a/src/components/main/QuizForm/QuizForm.tsx
+++ b/src/components/main/QuizForm/QuizForm.tsx
@@ -11,7 +11,12 @@ import ToggleButton from '@/components/main/ToggleButton/ToggleButton';
 import useModal from '@/hooks/useModal';
 import { createdQuizPresetAtomWithLocalStorage } from '@/stores/quiz';
 import { theme } from '@/styles/theme';
-import { CreateQuizWithUrlType, GetQuizListOutput, QuizPresetType, QuizType } from '@/types/quiz';
+import {
+  CreateQuizWithUrlType,
+  GetQuizListOutput,
+  QuizPresetType,
+  QuizType,
+} from '@/types/quiz';
 
 import * as styles from './QuizForm.style';
 
@@ -23,36 +28,37 @@ interface QuizFormProps {
 const convertURLtoFile = async (url: string) => {
   const response = await fetch(url);
   const data = await response.blob();
-  const ext = url.split(".").pop(); // url 구조에 맞게 수정할 것
-  const filename = url.split("/").pop() ?? 'noname'; // url 구조에 맞게 수정할 것
+  const ext = url.split('.').pop(); // url 구조에 맞게 수정할 것
+  const filename = url.split('/').pop() ?? 'noname'; // url 구조에 맞게 수정할 것
   const metadata = { type: `image/${ext}` };
   return new File([data], filename, metadata);
 };
 
 const convertQuizList = (quizList: QuizType[]) => {
-  return Promise.all(quizList.map(quiz => convertURLtoFile(quiz.imageUrl).then(imageFile => {
-    return {
-      hint: '',
-      image: imageFile,
-      answer: quiz.answer,
-      imageUrl: quiz.imageUrl,
-    };
-  })))
-}
+  return Promise.all(
+    quizList.map((quiz) =>
+      convertURLtoFile(quiz.imageUrl).then((imageFile) => {
+        return {
+          hint: '',
+          image: imageFile,
+          answer: quiz.answer,
+          imageUrl: quiz.imageUrl,
+        };
+      }),
+    ),
+  );
+};
 
 const QuizForm = ({ originData }: QuizFormProps) => {
   const { openModal } = useModal();
   const navigate = useNavigate();
-  const [presetData, setPresetData] = useState<QuizPresetType>(
-    {
-      isPrivate: originData?.isPrivate ?? false,
-      title: originData?.title ?? '',
-      presetPin: originData?.presetPin ?? '',
-      thumbnailUrl: originData?.thumbnailUrl ?? '',
-      hashTagList: originData?.hashTagList ?? []
-    },
-  );
-
+  const [presetData, setPresetData] = useState<QuizPresetType>({
+    isPrivate: originData?.isPrivate ?? false,
+    title: originData?.title ?? '',
+    presetPin: originData?.presetPin ?? '',
+    thumbnailUrl: originData?.thumbnailUrl ?? '',
+    hashtagList: originData?.hashtagList ?? [],
+  });
 
   const [quizList, setQuizList] = useState<CreateQuizWithUrlType[]>([]);
   const setCreatedPreset = useSetAtom(createdQuizPresetAtomWithLocalStorage);
@@ -99,10 +105,10 @@ const QuizForm = ({ originData }: QuizFormProps) => {
     setPresetData((prev) => ({ ...prev, isPrivate: status }));
   };
 
-  const handleHashtag = (hashTagList: string[]) => {
+  const handleHashtag = (hashtagList: string[]) => {
     setPresetData((prev) => ({
       ...prev,
-      hashTagList: hashTagList,
+      hashtagList: hashtagList,
     }));
   };
 
@@ -116,7 +122,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
   };
 
   const submitQuizData = async () => {
-    const { hashTagList: hashTagList, title, isPrivate } = presetData;
+    const { hashtagList: hashtagList, title, isPrivate } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
 
@@ -139,7 +145,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
         images,
         title,
         isPrivate,
-        hashTagList: hashTagList ?? []
+        hashtagList: hashtagList ?? [],
       });
 
       savePresetData(presetPin);
@@ -150,7 +156,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
   };
 
   useEffect(() => {
-    if(originData){
+    if (originData) {
       (async () => {
         const list = await convertQuizList(originData.quizList);
         setQuizList(list);
@@ -191,7 +197,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
             (퀴즈를 나타낼 수 있는 해시태그를 만들어주세요)
           </styles.InfoLabel>
           <HashtagInput
-            hashtag={presetData.hashTagList ?? []}
+            hashtag={presetData.hashtagList ?? []}
             setHashtag={handleHashtag}
           />
         </styles.InputWrapper>

--- a/src/components/main/QuizForm/QuizForm.tsx
+++ b/src/components/main/QuizForm/QuizForm.tsx
@@ -49,7 +49,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
       title: originData?.title ?? '',
       presetPin: originData?.presetPin ?? '',
       thumbnailUrl: originData?.thumbnailUrl ?? '',
-      hashtagList: originData?.hashtagList ?? []
+      hashTagList: originData?.hashTagList ?? []
     },
   );
 
@@ -99,10 +99,10 @@ const QuizForm = ({ originData }: QuizFormProps) => {
     setPresetData((prev) => ({ ...prev, isPrivate: status }));
   };
 
-  const handleHashtag = (hashtagList: string[]) => {
+  const handleHashtag = (hashTagList: string[]) => {
     setPresetData((prev) => ({
       ...prev,
-      hashtagList,
+      hashTagList: hashTagList,
     }));
   };
 
@@ -116,7 +116,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
   };
 
   const submitQuizData = async () => {
-    const { hashtagList, title, isPrivate } = presetData;
+    const { hashTagList: hashTagList, title, isPrivate } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
 
@@ -139,7 +139,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
         images,
         title,
         isPrivate,
-        hashTags: hashtagList ?? []
+        hashTagList: hashTagList ?? []
       });
 
       savePresetData(presetPin);
@@ -191,7 +191,7 @@ const QuizForm = ({ originData }: QuizFormProps) => {
             (퀴즈를 나타낼 수 있는 해시태그를 만들어주세요)
           </styles.InfoLabel>
           <HashtagInput
-            hashtag={presetData.hashtagList ?? []}
+            hashtag={presetData.hashTagList ?? []}
             setHashtag={handleHashtag}
           />
         </styles.InputWrapper>

--- a/src/components/main/QuizForm/index.ts
+++ b/src/components/main/QuizForm/index.ts
@@ -1,0 +1,3 @@
+import ModifyQuiz from './QuizForm';
+
+export default ModifyQuiz;

--- a/src/components/main/ToggleButton/ToggleButton.style.ts
+++ b/src/components/main/ToggleButton/ToggleButton.style.ts
@@ -1,11 +1,11 @@
 import styled, { css } from 'styled-components';
 
-export const Toggle = styled.input<{ onColor: string }>`
-  ${({ onColor }) => {
+export const Toggle = styled.input<{ $onColor: string }>`
+  ${({ $onColor }) => {
     return css`
       display: none;
       &:checked + ${Switch} {
-        background: ${onColor};
+        background: ${$onColor};
 
         &:before {
           transform: translate(2.5rem, -50%);
@@ -22,13 +22,13 @@ export const Label = styled.label`
   padding: 0.25rem;
 `;
 
-export const Switch = styled.div<{ offColor: string; circleColor: string }>`
-  ${({ offColor, circleColor }) => {
+export const Switch = styled.div<{ $offColor: string; $circleColor: string }>`
+  ${({ $offColor, $circleColor }) => {
     return css`
       position: relative;
       width: 4rem;
       height: 1.5rem;
-      background: ${offColor};
+      background: ${$offColor};
       border-radius: 12px;
       transition: 300ms all;
 
@@ -41,7 +41,7 @@ export const Switch = styled.div<{ offColor: string; circleColor: string }>`
         border-radius: 0.625rem;
         top: 50%;
         left: 0.125rem;
-        background: ${circleColor};
+        background: ${$circleColor};
         transform: translate(0, -50%);
       }
     `;

--- a/src/components/main/ToggleButton/ToggleButton.tsx
+++ b/src/components/main/ToggleButton/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import * as styles from './ToggleButton.style';
 
@@ -22,12 +22,12 @@ const ToggleButton = ({
   return (
     <styles.Label>
       <styles.Toggle
-        onColor={onColor}
+        $onColor={onColor}
         checked={checked}
         onChange={handleChange}
         type="checkbox"
       />
-      <styles.Switch offColor={offColor} circleColor={circleColor} />
+      <styles.Switch $offColor={offColor} $circleColor={circleColor} />
     </styles.Label>
   );
 };

--- a/src/components/pages/CreateQuiz/CreateQuiz.style.ts
+++ b/src/components/pages/CreateQuiz/CreateQuiz.style.ts
@@ -156,6 +156,8 @@ export const UploadQuizButton = styled.div`
       color: ${theme.colors.white};
       border-radius: 1.5rem;
       border: 1px solid #fff;
+      
+      cursor: pointer;
     `;
   }}
 `;

--- a/src/components/pages/CreateQuiz/CreateQuiz.style.ts
+++ b/src/components/pages/CreateQuiz/CreateQuiz.style.ts
@@ -1,10 +1,12 @@
 import styled, { css } from 'styled-components';
 
 export const CreateQuizWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
   margin: 1rem;
   gap: 0.5rem;
+
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 `;
 
 export const Title = styled.h1`

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -77,13 +77,21 @@ const CreateQuiz = () => {
     }));
   };
 
-  const savePresetData = async (presetPin: string) => {
+  const savePresetDataAndGameStart = async (presetPin: string) => {
     const { isPrivate, thumbnailUrl, title } =
       await QuizRepository.getQuizByPinAsync(presetPin);
     setCreatedPreset({
       type: 'ADD',
       item: { presetPin, isPrivate, thumbnailUrl, title },
     });
+
+    openModal(
+      <GameStartModal
+        presetPin={presetPin}
+        title={title}
+        thumbnailUrl={thumbnailUrl}
+      />,
+    );
   };
 
   const submitQuizData = async () => {
@@ -120,14 +128,7 @@ const CreateQuiz = () => {
       });
       await copyClipboard(presetPin);
       toast.success('프리셋을 생성하여 PIN을 복사했습니다.');
-      savePresetData(presetPin);
-      openModal(
-        <GameStartModal
-          presetPin={presetPin}
-          title={title}
-          thumbnailUrl={'test'}
-        />,
-      );
+      savePresetDataAndGameStart(presetPin);
       navigate(`/`);
     } catch (error) {
       console.error(error);

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -25,7 +25,7 @@ const CreateQuiz = () => {
     imageUrls: [], //미사용
     answers: [], //미사용
     hintList: [], //미사용
-    hashtagList: [],
+    hashTagList: [],
     title: '',
     isPrivate: false,
   });
@@ -70,10 +70,10 @@ const CreateQuiz = () => {
     setPresetData((prev) => ({ ...prev, isPrivate: status }));
   };
 
-  const handleHashtag = (hashtagList: string[]) => {
+  const handleHashtag = (hashTagList: string[]) => {
     setPresetData((prev) => ({
       ...prev,
-      hashtagList,
+      hashTagList,
     }));
   };
 
@@ -95,7 +95,7 @@ const CreateQuiz = () => {
   };
 
   const submitQuizData = async () => {
-    const { hashtagList, title, isPrivate } = presetData;
+    const { hashTagList, title, isPrivate } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
 
@@ -118,6 +118,7 @@ const CreateQuiz = () => {
         images,
         title,
         isPrivate,
+        hashTagList: hashTagList ?? []
       });
       await copyClipboard(presetPin);
       toast.success('퀴즈 프리셋을 생성하여 PIN을 복사했습니다.');
@@ -131,7 +132,7 @@ const CreateQuiz = () => {
   return (
     <styles.CreateQuizWrapper>
       <styles.Title>
-        <styles.PointTitle>새로운 퀴즈 프리셋</styles.PointTitle> 만들기
+        <styles.PointTitle>퀴즈 프리셋</styles.PointTitle> 만들기
       </styles.Title>
       <styles.GetPresetButton>
         기존 퀴즈 프리셋 복사해서 만들기
@@ -167,7 +168,7 @@ const CreateQuiz = () => {
             (퀴즈를 나타낼 수 있는 해시태그를 만들어주세요)
           </styles.InfoLabel>
           <HashtagInput
-            hashtag={presetData.hashtagList}
+            hashtag={presetData.hashTagList}
             setHashtag={handleHashtag}
           />
         </styles.InputWrapper>
@@ -201,7 +202,7 @@ const CreateQuiz = () => {
         )}
       </styles.QuizListWrapper>
       <styles.AddNewQuizButton onClick={submitQuizData}>
-        퀴즈 프리셋 생성하기
+        프리셋 생성하기
       </styles.AddNewQuizButton>
     </styles.CreateQuizWrapper>
   );

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -188,13 +188,15 @@ const CreateQuiz = () => {
               modifyQuiz={modifyCurrentQuiz}
             />
           ))}
-        <styles.AddQuizWrapper>
-          <styles.UploadText src="/src/assets/images/uploadQuizText.svg" />
-          <styles.ArrowIcon src="/src/assets/icons/arrowIcon.svg" />
-          <styles.UploadQuizButton onClick={openAddQuizModal}>
-            추가하기
-          </styles.UploadQuizButton>
-        </styles.AddQuizWrapper>
+        {quizList.length < 10 && (
+          <styles.AddQuizWrapper>
+            <styles.UploadText src="/src/assets/images/uploadQuizText.svg" />
+            <styles.ArrowIcon src="/src/assets/icons/arrowIcon.svg" />
+            <styles.UploadQuizButton onClick={openAddQuizModal}>
+              추가하기
+            </styles.UploadQuizButton>
+          </styles.AddQuizWrapper>
+        )}
       </styles.QuizListWrapper>
       <styles.AddNewQuizButton onClick={submitQuizData}>
         퀴즈 생성하기

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -95,7 +95,7 @@ const CreateQuiz = () => {
   };
 
   const submitQuizData = async () => {
-    const { hashtagList, title, isPrivate } = presetData;
+    const { hashtagList, title, isPrivate, hintList } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
 
@@ -119,6 +119,7 @@ const CreateQuiz = () => {
         title,
         isPrivate,
         hashtagList: hashtagList ?? [],
+        hintList,
       });
       await copyClipboard(presetPin);
       toast.success('퀴즈 프리셋을 생성하여 PIN을 복사했습니다.');

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -25,7 +25,7 @@ const CreateQuiz = () => {
     imageUrls: [], //미사용
     answers: [], //미사용
     hintList: [], //미사용
-    hashTagList: [],
+    hashtagList: [],
     title: '',
     isPrivate: false,
   });
@@ -70,10 +70,10 @@ const CreateQuiz = () => {
     setPresetData((prev) => ({ ...prev, isPrivate: status }));
   };
 
-  const handleHashtag = (hashTagList: string[]) => {
+  const handleHashtag = (hashtagList: string[]) => {
     setPresetData((prev) => ({
       ...prev,
-      hashTagList,
+      hashtagList,
     }));
   };
 
@@ -95,7 +95,7 @@ const CreateQuiz = () => {
   };
 
   const submitQuizData = async () => {
-    const { hashTagList, title, isPrivate } = presetData;
+    const { hashtagList, title, isPrivate } = presetData;
     const images = quizList.map((value) => value.image);
     const answers = quizList.map((value) => value.answer);
 
@@ -118,7 +118,7 @@ const CreateQuiz = () => {
         images,
         title,
         isPrivate,
-        hashTagList: hashTagList ?? []
+        hashtagList: hashtagList ?? [],
       });
       await copyClipboard(presetPin);
       toast.success('퀴즈 프리셋을 생성하여 PIN을 복사했습니다.');
@@ -168,7 +168,7 @@ const CreateQuiz = () => {
             (퀴즈를 나타낼 수 있는 해시태그를 만들어주세요)
           </styles.InfoLabel>
           <HashtagInput
-            hashtag={presetData.hashTagList}
+            hashtag={presetData.hashtagList}
             setHashtag={handleHashtag}
           />
         </styles.InputWrapper>

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -112,13 +112,6 @@ const CreateQuiz = () => {
       return;
     }
 
-    const formData = new FormData();
-    images.map((image) => formData.append('images', image));
-    answers.map((answer) => formData.append('answers', answer));
-    formData.append('title', title);
-    formData.append('isPrivate', JSON.stringify(isPrivate));
-    // formData.append('hashtag', JSON.stringify(isPrivate)); //Fixme: 서버 통신방식 확인 후 추가하
-
     try {
       const { presetPin } = await QuizRepository.postCreateNewPresetAsync({
         answers,

--- a/src/components/pages/CreateQuiz/CreateQuiz.tsx
+++ b/src/components/pages/CreateQuiz/CreateQuiz.tsx
@@ -60,7 +60,7 @@ const CreateQuiz = () => {
   const handleTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
     const title = event.target.value;
     if (title.length > 50) {
-      toast.error('프리셋 제목은 50글자 이상 지정할 수 없습니다. ');
+      toast.error('퀴즈 프리셋 제목은 50글자 이상 지정할 수 없습니다. ');
       return;
     }
     setPresetData((prev) => ({ ...prev, title: event.target.value }));
@@ -120,7 +120,7 @@ const CreateQuiz = () => {
         isPrivate,
       });
       await copyClipboard(presetPin);
-      toast.success('프리셋을 생성하여 PIN을 복사했습니다.');
+      toast.success('퀴즈 프리셋을 생성하여 PIN을 복사했습니다.');
       savePresetDataAndGameStart(presetPin);
       navigate(`/`);
     } catch (error) {
@@ -131,9 +131,11 @@ const CreateQuiz = () => {
   return (
     <styles.CreateQuizWrapper>
       <styles.Title>
-        <styles.PointTitle>새로운 퀴즈</styles.PointTitle> 만들기
+        <styles.PointTitle>새로운 퀴즈 프리셋</styles.PointTitle> 만들기
       </styles.Title>
-      <styles.GetPresetButton>기존 퀴즈 복사해서 만들기</styles.GetPresetButton>
+      <styles.GetPresetButton>
+        기존 퀴즈 프리셋 복사해서 만들기
+      </styles.GetPresetButton>
       <styles.NameLabelWrapper>
         <styles.InputWrapper>
           <styles.NameLabel>
@@ -199,7 +201,7 @@ const CreateQuiz = () => {
         )}
       </styles.QuizListWrapper>
       <styles.AddNewQuizButton onClick={submitQuizData}>
-        퀴즈 생성하기
+        퀴즈 프리셋 생성하기
       </styles.AddNewQuizButton>
     </styles.CreateQuizWrapper>
   );

--- a/src/components/pages/ModifyQuiz/ModifyQuiz.style.ts
+++ b/src/components/pages/ModifyQuiz/ModifyQuiz.style.ts
@@ -1,0 +1,182 @@
+import styled, { css } from 'styled-components';
+
+export const Wrapper = styled.div`
+  margin: 1rem;
+  gap: 0.5rem;
+
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.title.fontFamily};
+      font-size: ${theme.fonts.title.fontSize}rem;
+      font-weight: ${theme.fonts.title.fontWeight};
+      line-height: ${theme.fonts.title.lineHeight};
+      text-align: center;
+    `;
+  }}
+`;
+
+export const PointTitle = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+
+export const GetPresetButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      margin-left: auto;
+      margin-top: 1rem;
+      padding: 0.6rem 1rem;
+
+      border-radius: 1.5625rem;
+      border: 1px solid ${theme.colors.white};
+
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: ${theme.fonts.body2R.fontSize}rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+    `;
+  }}
+`;
+
+export const PrivateWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+  padding: 0.38rem;
+`;
+
+export const NameLabelWrapper = styled.span`
+  display: flex;
+  flex-direction: column;
+  gap: 0.88rem;
+`;
+
+export const NameLabel = styled.label`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.darkblue200};
+      font-family: ${theme.fonts.subtitle2B.fontFamily};
+      font-size: ${theme.fonts.subtitle2B.fontSize}rem;
+      font-weight: ${theme.fonts.subtitle2B.fontWeight};
+    `;
+  }}
+`;
+
+export const InfoLabel = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body3.fontFamily};
+      font-size: ${theme.fonts.body3.fontSize}rem;
+      font-weight: ${theme.fonts.body3.fontWeight};
+    `;
+  }}
+`;
+
+export const CountLabel = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2B.fontFamily};
+      font-size: ${theme.fonts.body2B.fontSize}rem;
+      font-weight: ${theme.fonts.body2B.fontWeight};
+      line-height: ${theme.fonts.body2B.lineHeight};
+    `;
+  }}
+`;
+
+export const NameInput = styled.input`
+  ${({ theme }) => {
+    return css`
+      height: 2rem;
+      padding: 0.5rem;
+      border: 1px solid ${theme.colors.white};
+      border-radius: 0.5rem;
+
+      font-family: ${theme.fonts.body3.fontFamily};
+      font-size: ${theme.fonts.body3.fontSize}rem;
+      font-weight: ${theme.fonts.body3.fontWeight};
+      line-height: ${theme.fonts.body3.lineHeight};
+      color: ${theme.colors.white};
+      background-color: transparent;
+
+      &::placeholder {
+        color: ${theme.colors.black};
+      }
+    `;
+  }}
+`;
+
+export const QuizListWrapper = styled.section`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.62rem;
+  margin: 0 1.06rem;
+  justify-content: space-between;
+`;
+export const AddQuizWrapper = styled.div`
+  display: flex;
+  width: 8.125rem;
+  height: 11.25rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.62rem;
+  border-radius: 1rem;
+  border: 1px solid #fff;
+`;
+export const UploadQuizButton = styled.div`
+  ${({ theme }) => {
+    return css`
+      width: 6.5rem;
+      height: 1.5rem;
+      justify-content: center;
+      align-items: center;
+
+      text-align: center;
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: ${theme.fonts.body2R.fontSize}rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+      line-height: ${theme.fonts.body2R.lineHeight};
+      color: ${theme.colors.white};
+      border-radius: 1.5rem;
+      border: 1px solid #fff;
+    `;
+  }}
+`;
+
+export const AddNewQuizButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      width: 10rem;
+      height: 2rem;
+      margin: 2rem auto;
+
+      border-radius: 1.5rem;
+      border: 1px solid ${theme.colors.darkblue400};
+      text-align: center;
+
+      font-family: ${theme.fonts.body2B.fontFamily};
+      font-size: ${theme.fonts.body2B.fontSize}rem;
+      font-weight: ${theme.fonts.body2B.fontWeight};
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+export const UploadText = styled.img``;
+export const ArrowIcon = styled.img``;

--- a/src/components/pages/ModifyQuiz/ModifyQuiz.tsx
+++ b/src/components/pages/ModifyQuiz/ModifyQuiz.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import QuizForm from '@/components/main/QuizForm/QuizForm';
 import useGetPresetByPin from '@/hooks/useGetPresetByPin';
@@ -6,17 +6,16 @@ import useGetPresetByPin from '@/hooks/useGetPresetByPin';
 import * as styles from './ModifyQuiz.style';
 
 const ModifyQuiz = () => {
-  const { state } = useLocation();
-  const presetPin = state.presetPin ?? '';
+  const { presetPin } = useParams();
 
-  const originData = useGetPresetByPin(presetPin);
+  const originData = useGetPresetByPin(presetPin ?? '');
 
   return (
     <styles.Wrapper>
       <styles.Title>
         <styles.PointTitle>퀴즈 프리셋 수정</styles.PointTitle>하기
       </styles.Title>
-      {originData && (<QuizForm originData={originData} presetPin={presetPin}/>)}
+      {originData && <QuizForm originData={originData} presetPin={presetPin} />}
     </styles.Wrapper>
   );
 };

--- a/src/components/pages/ModifyQuiz/ModifyQuiz.tsx
+++ b/src/components/pages/ModifyQuiz/ModifyQuiz.tsx
@@ -1,0 +1,24 @@
+import { useLocation } from 'react-router-dom';
+
+import QuizForm from '@/components/main/QuizForm/QuizForm';
+import useGetPresetByPin from '@/hooks/useGetPresetByPin';
+
+import * as styles from './ModifyQuiz.style';
+
+const ModifyQuiz = () => {
+  const { state } = useLocation();
+  const presetPin = state.presetPin ?? '';
+
+  const originData = useGetPresetByPin(presetPin);
+
+  return (
+    <styles.Wrapper>
+      <styles.Title>
+        <styles.PointTitle>퀴즈 프리셋 수정</styles.PointTitle>하기
+      </styles.Title>
+      {originData && (<QuizForm originData={originData} presetPin={presetPin}/>)}
+    </styles.Wrapper>
+  );
+};
+
+export default ModifyQuiz;

--- a/src/components/pages/ModifyQuiz/index.ts
+++ b/src/components/pages/ModifyQuiz/index.ts
@@ -1,0 +1,3 @@
+import ModifyQuiz from './ModifyQuiz';
+
+export default ModifyQuiz;

--- a/src/components/pages/MyQuiz/MyQuiz.style.ts
+++ b/src/components/pages/MyQuiz/MyQuiz.style.ts
@@ -1,0 +1,150 @@
+import styled, { css } from 'styled-components';
+
+export const Wrapper = styled.div`
+  margin: 1rem;
+  gap: 0.5rem;
+
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.title.fontFamily};
+      font-size: ${theme.fonts.title.fontSize}rem;
+      font-weight: ${theme.fonts.title.fontWeight};
+      line-height: ${theme.fonts.title.lineHeight};
+      text-align: center;
+    `;
+  }}
+`;
+
+export const PointTitle = styled.span`
+  ${({ theme }) => {
+    return css`
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+
+export const QuizListWrapper = styled.section`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.62rem;
+  margin: 0 1.06rem;
+  justify-content: space-between;
+`;
+
+export const AddQuizWrapper = styled.div`
+  display: flex;
+  width: 8.125rem;
+  height: 11.25rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.62rem;
+  border-radius: 1rem;
+  border: 1px solid #fff;
+`;
+
+export const AddNewQuizButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      width: 10rem;
+      height: 2rem;
+      margin: 2rem auto;
+
+      border-radius: 1.5rem;
+      border: 1px solid ${theme.colors.darkblue400};
+      text-align: center;
+
+      font-family: ${theme.fonts.body2B.fontFamily};
+      font-size: ${theme.fonts.body2B.fontSize}rem;
+      font-weight: ${theme.fonts.body2B.fontWeight};
+      color: ${theme.colors.darkblue400};
+    `;
+  }}
+`;
+
+export const CreateQuizWrapper = styled.div<{ image: string }>`
+  ${({ image }) => {
+    return css`
+      position: relative;
+      width: 8.125rem;
+      height: 11.25rem;
+      padding: 0;
+      border-radius: 0.75rem;
+      border: 1px solid #fff;
+      box-shadow: 0px 0px 4px 0px #a1db00;
+      background-image: url(${image});
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: cover;
+    `;
+  }}
+`;
+export const QuizModifyWrapper = styled.div`
+  display: none;
+  position: absolute;
+  margin: -0.0625rem;
+  padding: 0;
+  width: 8.125rem;
+  height: 11.25rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.12rem;
+
+  border-radius: 0.75rem;
+  background: rgba(20, 21, 20, 0.6);
+  ${CreateQuizWrapper}:hover & {
+    display: flex;
+  }
+`;
+export const ModifyButton = styled.button`
+  ${({ theme }) => {
+    return css`
+      display: flex;
+      padding: 0.625rem 1.25rem;
+      justify-content: center;
+      align-items: center;
+      gap: 0.625rem;
+
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.caption.fontFamily};
+      font-weight: ${theme.fonts.caption.fontWeight};
+      font-size: 0.625rem;
+      border-radius: 1.5625rem;
+      border: 1px solid #fff;
+      box-shadow: 0px 0px 8px 0px #fff;
+    `;
+  }}
+`;
+
+export const AnswerText = styled.p`
+  ${({ theme }) => {
+    return css`
+      margin-top: 9rem;
+      margin-left: 0.62rem;
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.body2R.fontFamily};
+      font-size: 0.75rem;
+      font-weight: ${theme.fonts.body2R.fontWeight};
+    `;
+  }}
+`;
+
+export const HintText = styled.p`
+  ${({ theme }) => {
+    return css`
+      margin-left: 0.62rem;
+      color: ${theme.colors.white};
+      font-family: ${theme.fonts.caption.fontFamily};
+      font-size: 0.625rem;
+      font-weight: ${theme.fonts.caption.fontWeight};
+    `;
+  }}
+`;

--- a/src/components/pages/MyQuiz/MyQuiz.tsx
+++ b/src/components/pages/MyQuiz/MyQuiz.tsx
@@ -29,10 +29,10 @@ const MyQuiz = () => {
           item: presetList[index],
         });
 
-        toast.success('해당 프리셋을 삭제하였습니다.');
+        toast.success('해당 퀴즈 프리셋을 삭제하였습니다.');
       } catch (e) {
         toast.error(
-          '해당 프리셋을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.',
+          '해당 퀴즈 프리셋을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.',
         );
       }
     }

--- a/src/components/pages/MyQuiz/MyQuiz.tsx
+++ b/src/components/pages/MyQuiz/MyQuiz.tsx
@@ -1,12 +1,72 @@
+import { useAtom } from 'jotai';
+import { toast } from 'react-toastify';
+
+import QuizRepository from '@/apis/quiz';
+import GameStartModal from '@/components/main/GameStartModal';
+import ModifyPresetImageView from '@/components/main/ModifyPresetImageView';
+import useModal from '@/hooks/useModal';
+import { createdQuizPresetAtomWithLocalStorage } from '@/stores/quiz';
+
 import * as styles from './MyQuiz.style';
 
 const MyQuiz = () => {
+  const { openModal } = useModal();
+  const [{ presetList }, setPresetList] = useAtom(
+    createdQuizPresetAtomWithLocalStorage,
+  );
+
+  // TODO: 프리셋 수정 이동
+  const modifyCurrentQuiz = (index: number) => {
+    console.log('update');
+  };
+
+  const removeCurrentQuiz = async (index: number) => {
+    if (confirm('해당 퀴즈 프리셋을 삭제하시겠습니까?')) {
+      try {
+        await QuizRepository.deletePresetAsync(presetList[index].presetPin);
+        setPresetList({
+          type: 'DELETE',
+          item: presetList[index],
+        });
+
+        toast.success('해당 프리셋을 삭제하였습니다.');
+      } catch (e) {
+        toast.error(
+          '해당 프리셋을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.',
+        );
+      }
+    }
+  };
+
+  const startCurrentQuiz = (index: number) => {
+    const item = presetList[index];
+    openModal(
+      <GameStartModal
+        presetPin={item.presetPin}
+        title={item.title}
+        thumbnailUrl={item.thumbnailUrl}
+      />,
+    );
+  };
+
   return (
     <styles.Wrapper>
       <styles.Title>
         <styles.PointTitle>나의 퀴즈</styles.PointTitle>
       </styles.Title>
-      <styles.QuizListWrapper></styles.QuizListWrapper>
+      <styles.QuizListWrapper>
+        {presetList.map((preset, index) => (
+          <ModifyPresetImageView
+            key={preset.presetPin}
+            url={preset.thumbnailUrl}
+            index={index}
+            title={preset.title}
+            startQuiz={startCurrentQuiz}
+            removeQuiz={removeCurrentQuiz}
+            modifyQuiz={modifyCurrentQuiz}
+          />
+        ))}
+      </styles.QuizListWrapper>
     </styles.Wrapper>
   );
 };

--- a/src/components/pages/MyQuiz/MyQuiz.tsx
+++ b/src/components/pages/MyQuiz/MyQuiz.tsx
@@ -19,11 +19,7 @@ const MyQuiz = () => {
   );
 
   const modifyCurrentQuiz = (index: number) => {
-    navigate('/modify', {
-      state: {
-        presetPin : presetList[index].presetPin
-      }
-    });
+    navigate(`/modify/${presetList[index].presetPin}`);
   };
 
   const removeCurrentQuiz = async (index: number) => {

--- a/src/components/pages/MyQuiz/MyQuiz.tsx
+++ b/src/components/pages/MyQuiz/MyQuiz.tsx
@@ -1,0 +1,14 @@
+import * as styles from './MyQuiz.style';
+
+const MyQuiz = () => {
+  return (
+    <styles.Wrapper>
+      <styles.Title>
+        <styles.PointTitle>나의 퀴즈</styles.PointTitle>
+      </styles.Title>
+      <styles.QuizListWrapper></styles.QuizListWrapper>
+    </styles.Wrapper>
+  );
+};
+
+export default MyQuiz;

--- a/src/components/pages/MyQuiz/MyQuiz.tsx
+++ b/src/components/pages/MyQuiz/MyQuiz.tsx
@@ -1,4 +1,5 @@
 import { useAtom } from 'jotai';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import QuizRepository from '@/apis/quiz';
@@ -10,14 +11,19 @@ import { createdQuizPresetAtomWithLocalStorage } from '@/stores/quiz';
 import * as styles from './MyQuiz.style';
 
 const MyQuiz = () => {
+  const navigate = useNavigate();
+
   const { openModal } = useModal();
   const [{ presetList }, setPresetList] = useAtom(
     createdQuizPresetAtomWithLocalStorage,
   );
 
-  // TODO: 프리셋 수정 이동
   const modifyCurrentQuiz = (index: number) => {
-    console.log('update');
+    navigate('/modify', {
+      state: {
+        presetPin : presetList[index].presetPin
+      }
+    });
   };
 
   const removeCurrentQuiz = async (index: number) => {

--- a/src/components/pages/QuizSearch/QuizSearch.tsx
+++ b/src/components/pages/QuizSearch/QuizSearch.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
-import PresetCard from '@/components/main/PresetCard';
 import GameStartModal from '@/components/main/GameStartModal';
+import PresetCard from '@/components/main/PresetCard';
 import useGetPresetList from '@/hooks/useGetPresetList';
 import useModal from '@/hooks/useModal';
 import { QuizPresetType } from '@/types/quiz';
@@ -61,12 +61,12 @@ const QuizSearch = () => {
       <styles.QuizPresetWrapper>
         {presetList &&
           presetList.map((preset) => (
-            <styles.QuizPresetCard >
+            <styles.QuizPresetCard>
               <PresetCard
-              key={preset.presetPin}
+                key={preset.presetPin}
                 title={preset.title}
                 thumbnailUrl={preset.thumbnailUrl}
-                hashTagList={preset.hashTagList}
+                hashtagList={preset.hashtagList}
                 handleClick={() => handleClick(preset)}
               />
             </styles.QuizPresetCard>

--- a/src/components/pages/QuizSearch/QuizSearch.tsx
+++ b/src/components/pages/QuizSearch/QuizSearch.tsx
@@ -66,7 +66,7 @@ const QuizSearch = () => {
               key={preset.presetPin}
                 title={preset.title}
                 thumbnailUrl={preset.thumbnailUrl}
-                hashtagList={preset.hashtagList}
+                hashTagList={preset.hashTagList}
                 handleClick={() => handleClick(preset)}
               />
             </styles.QuizPresetCard>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -5,6 +5,7 @@ import GameManage from '@/components/common/GameManage';
 import CreateQuiz from '@/components/pages/CreateQuiz';
 import Home from '@/components/pages/Home';
 import Landing from '@/components/pages/Landing';
+import ModifyQuiz from '@/components/pages/ModifyQuiz/ModifyQuiz';
 import MyQuiz from '@/components/pages/MyQuiz/MyQuiz';
 import QuizAnswer from '@/components/pages/QuizAnswer';
 import QuizPlay from '@/components/pages/QuizPlay';
@@ -34,6 +35,10 @@ const router = createBrowserRouter([
           {
             path: 'my-quiz',
             element: <MyQuiz />,
+          },
+          {
+            path: 'modify',
+            element: <ModifyQuiz />,
           },
         ],
       },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -37,7 +37,7 @@ const router = createBrowserRouter([
             element: <MyQuiz />,
           },
           {
-            path: 'modify',
+            path: 'modify/:presetPin',
             element: <ModifyQuiz />,
           },
         ],

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,61 +1,66 @@
 import { createBrowserRouter } from 'react-router-dom';
 
 import BasicLayout from '@/components/common/BasicLayout';
+import GameManage from '@/components/common/GameManage';
 import CreateQuiz from '@/components/pages/CreateQuiz';
 import Home from '@/components/pages/Home';
 import Landing from '@/components/pages/Landing';
-import GameManage from '@/components/common/GameManage';
+import MyQuiz from '@/components/pages/MyQuiz/MyQuiz';
 import QuizAnswer from '@/components/pages/QuizAnswer';
 import QuizPlay from '@/components/pages/QuizPlay';
 import QuizResult from '@/components/pages/QuizResult';
 import QuizSearch from '@/components/pages/QuizSearch';
 
 const router = createBrowserRouter([
-    {
-      path: '/',
-      errorElement: <div>오류</div>,
-      children: [
-        {
-          element: <BasicLayout />,
-          children: [
-            {
-              index: true,
-              element: <Home />,
-            },
-            {
-              path: 'create',
-              element: <CreateQuiz />,
-            },
-            {
-              path: 'search',
-              element: <QuizSearch />,
-            },
-          ]
-        },
-        {
-          element: <GameManage />,
-          path: 'quiz',
-          children: [
-            {
-              index: true,
-              element: <QuizPlay />,
-            },
-            {
-              path: 'answer',
-              element: <QuizAnswer />,
-            },
-            {
-              path: 'loading',
-              element: <Landing />,
-            },
-            {
-              path: 'result',
-              element: <QuizResult />,
-            },
-          ],
-        },
-      ],
-    },
-  ]);
+  {
+    path: '/',
+    errorElement: <div>오류</div>,
+    children: [
+      {
+        element: <BasicLayout />,
+        children: [
+          {
+            index: true,
+            element: <Home />,
+          },
+          {
+            path: 'create',
+            element: <CreateQuiz />,
+          },
+          {
+            path: 'search',
+            element: <QuizSearch />,
+          },
+          {
+            path: 'my-quiz',
+            element: <MyQuiz />,
+          },
+        ],
+      },
+      {
+        element: <GameManage />,
+        path: 'quiz',
+        children: [
+          {
+            index: true,
+            element: <QuizPlay />,
+          },
+          {
+            path: 'answer',
+            element: <QuizAnswer />,
+          },
+          {
+            path: 'loading',
+            element: <Landing />,
+          },
+          {
+            path: 'result',
+            element: <QuizResult />,
+          },
+        ],
+      },
+    ],
+  },
+]);
 
-  export default router;
+export default router;

--- a/src/stores/quiz/actions.ts
+++ b/src/stores/quiz/actions.ts
@@ -1,10 +1,15 @@
 import { atom } from 'jotai';
 
-import { quizPlayStateAtom } from '@/stores/quiz';
+import {
+  STORAGE_KEY,
+  createdQuizPresetAtom,
+  quizPlayStateAtom,
+} from '@/stores/quiz';
 import type {
   UpdateCurrentScoreType,
   UpdateQuizStartType,
 } from '@/types/atom/quiz';
+import { QuizPresetType } from '@/types/quiz';
 
 export const startQuizGameAtom = atom(
   null,
@@ -61,5 +66,19 @@ export const controlCurrentScoreAtom = atom(
       totalScore,
       currentIndex: prevAtom.currentIndex + 1,
     });
+  },
+);
+
+export const createdQuizPresetAtomWithLocalStorage = atom(
+  (get) => get(createdQuizPresetAtom),
+  (get, set, newPreset: QuizPresetType) => {
+    const prevAtom = get(createdQuizPresetAtom);
+    const newValue = {
+      ...prevAtom,
+      presetList: [...prevAtom.presetList, newPreset],
+    };
+
+    set(createdQuizPresetAtom, newValue);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newValue));
   },
 );

--- a/src/stores/quiz/atoms.ts
+++ b/src/stores/quiz/atoms.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 
-import { QuizPlayStateType } from '@/types/atom/quiz';
+import { CreatedQuizStateType, QuizPlayStateType } from '@/types/atom/quiz';
 
 export const quizPlayStateAtom = atom<QuizPlayStateType>({
   isPlaying: false,
@@ -11,4 +11,17 @@ export const quizPlayStateAtom = atom<QuizPlayStateType>({
   totalScore: 0,
   delayBeforeStart: 3,
   timeToSolveQuiz: 3,
+});
+
+export const STORAGE_KEY = 'createdQuiz';
+const getInitialValue = () => {
+  const item = localStorage.getItem(STORAGE_KEY);
+  if (item !== null) {
+    return JSON.parse(item);
+  }
+  return [];
+};
+
+export const createdQuizPresetAtom = atom<CreatedQuizStateType>({
+  presetList: getInitialValue(),
 });

--- a/src/stores/quiz/atoms.ts
+++ b/src/stores/quiz/atoms.ts
@@ -15,6 +15,10 @@ export const quizPlayStateAtom = atom<QuizPlayStateType>({
 
 export const STORAGE_KEY = 'createdQuiz';
 
+const isCreatedQuizStateType = (obj: object): obj is CreatedQuizStateType => {
+  return 'presetList' in obj;
+};
+
 const getInitialValue = (): CreatedQuizStateType => {
   const item = localStorage.getItem(STORAGE_KEY);
   if (item !== null) {
@@ -29,7 +33,3 @@ const getInitialValue = (): CreatedQuizStateType => {
 export const createdQuizPresetAtom = atom<CreatedQuizStateType>(
   getInitialValue(),
 );
-
-const isCreatedQuizStateType = (obj: object): obj is CreatedQuizStateType => {
-  return 'presetList' in obj;
-};

--- a/src/stores/quiz/atoms.ts
+++ b/src/stores/quiz/atoms.ts
@@ -14,14 +14,22 @@ export const quizPlayStateAtom = atom<QuizPlayStateType>({
 });
 
 export const STORAGE_KEY = 'createdQuiz';
-const getInitialValue = () => {
+
+const getInitialValue = (): CreatedQuizStateType => {
   const item = localStorage.getItem(STORAGE_KEY);
   if (item !== null) {
-    return JSON.parse(item);
+    const parsed = JSON.parse(item);
+    if (isCreatedQuizStateType(parsed)) {
+      return parsed;
+    }
   }
-  return [];
+  return { presetList: [] };
 };
 
-export const createdQuizPresetAtom = atom<CreatedQuizStateType>({
-  presetList: getInitialValue(),
-});
+export const createdQuizPresetAtom = atom<CreatedQuizStateType>(
+  getInitialValue(),
+);
+
+const isCreatedQuizStateType = (obj: object): obj is CreatedQuizStateType => {
+  return 'presetList' in obj;
+};

--- a/src/types/atom/quiz/index.ts
+++ b/src/types/atom/quiz/index.ts
@@ -1,4 +1,4 @@
-import { QuizType } from '@/types/quiz';
+import { QuizPresetType, QuizType } from '@/types/quiz';
 
 export interface QuizPlayStateType {
   /** 현재 게임이 진행 중임을 나타내는 isPlaying */
@@ -29,3 +29,7 @@ export type UpdateQuizStartType = Pick<
 >;
 
 export type UpdateCurrentScoreType = { isCorrect: boolean; quizIndex: number };
+
+export interface CreatedQuizStateType {
+  presetList: QuizPresetType[];
+}

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -14,7 +14,7 @@ export interface QuizPresetType {
   title: string;
   presetPin: string;
   thumbnailUrl: string;
-  hashtagList?: string[]; //Fix : 추후 추가되면 ?제거
+  hashTagList?: string[]; //Fix : 추후 추가되면 ?제거
 }
 
 export type QuizPresetTypeWithPin = QuizPresetType & QuizPresetPinType;
@@ -24,7 +24,7 @@ export interface CreatePresetType {
   answers: string[];
   title: string;
   isPrivate: boolean;
-  hashTags: string[];
+  hashTagList: string[];
 }
 
 export interface CreateQuizType {
@@ -39,7 +39,7 @@ export type CreateQuizWithUrlType = CreateQuizType & {
 
 export type CreatePresetWithUrlType = CreatePresetType & {
   imageUrls: string[];
-  hashtagList: string[];
+  hashTagList: string[];
   hintList: string[];
 };
 
@@ -48,7 +48,7 @@ export type GetQuizListOutput = QuizTypeWithPin & {
   isPrivate: boolean;
   thumbnailUrl: string;
   title: string;
-  hashtagList: string[];
+  hashTagList: string[];
 };
 
 export type PlayableQuizPresetType = QuizPresetType & { quizList: QuizType[] };

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -24,6 +24,7 @@ export interface CreatePresetType {
   answers: string[];
   title: string;
   isPrivate: boolean;
+  hashTags: string[];
 }
 
 export interface CreateQuizType {
@@ -47,6 +48,7 @@ export type GetQuizListOutput = QuizTypeWithPin & {
   isPrivate: boolean;
   thumbnailUrl: string;
   title: string;
+  hashtagList: string[];
 };
 
 export type PlayableQuizPresetType = QuizPresetType & { quizList: QuizType[] };

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -13,8 +13,8 @@ export interface QuizPresetType {
   isPrivate: boolean;
   title: string;
   presetPin: string;
-  thumbnailUrl: string; 
-  hashtagList?: string[] ;//Fix : 추후 추가되면 ?제거
+  thumbnailUrl: string;
+  hashtagList?: string[]; //Fix : 추후 추가되면 ?제거
 }
 
 export type QuizPresetTypeWithPin = QuizPresetType & QuizPresetPinType;
@@ -31,7 +31,10 @@ export interface CreateQuizType {
   answer: string;
 }
 
-export type CreateQuizWithUrlType = CreateQuizType & { imageUrl: string, hint: string };
+export type CreateQuizWithUrlType = CreateQuizType & {
+  imageUrl: string;
+  hint: string;
+};
 
 export type CreatePresetWithUrlType = CreatePresetType & {
   imageUrls: string[];
@@ -41,6 +44,9 @@ export type CreatePresetWithUrlType = CreatePresetType & {
 
 export type GetQuizListOutput = QuizTypeWithPin & {
   quizList: QuizType[];
+  isPrivate: boolean;
+  thumbnailUrl: string;
+  title: string;
 };
 
 export type PlayableQuizPresetType = QuizPresetType & { quizList: QuizType[] };

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -27,7 +27,7 @@ export interface CreatePresetType {
 }
 
 export interface CreateQuizType {
-  image: File | null;
+  image: File;
   answer: string;
 }
 

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -14,7 +14,7 @@ export interface QuizPresetType {
   title: string;
   presetPin: string;
   thumbnailUrl: string;
-  hashTagList?: string[]; //Fix : 추후 추가되면 ?제거
+  hashtagList?: string[]; //Fix : 추후 추가되면 ?제거
 }
 
 export type QuizPresetTypeWithPin = QuizPresetType & QuizPresetPinType;
@@ -24,7 +24,7 @@ export interface CreatePresetType {
   answers: string[];
   title: string;
   isPrivate: boolean;
-  hashTagList: string[];
+  hashtagList: string[];
 }
 
 export interface CreateQuizType {
@@ -39,7 +39,7 @@ export type CreateQuizWithUrlType = CreateQuizType & {
 
 export type CreatePresetWithUrlType = CreatePresetType & {
   imageUrls: string[];
-  hashTagList: string[];
+  hashtagList: string[];
   hintList: string[];
 };
 
@@ -48,7 +48,7 @@ export type GetQuizListOutput = QuizTypeWithPin & {
   isPrivate: boolean;
   thumbnailUrl: string;
   title: string;
-  hashTagList: string[];
+  hashtagList: string[];
 };
 
 export type PlayableQuizPresetType = QuizPresetType & { quizList: QuizType[] };

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -25,6 +25,7 @@ export interface CreatePresetType {
   title: string;
   isPrivate: boolean;
   hashtagList: string[];
+  hintList: string[];
 }
 
 export interface CreateQuizType {


### PR DESCRIPTION
## Github Issue 번호
59

## 작업 내용
- 퀴즈 생성 페이지 수정
  - 퀴즈 생성 후 저장된 정보를 다시 받아와 스토리지 저장 및 게임 시작 모달 오픈 시 사용할 수 있도록 수정 (현재는 모든 정보를 저장하나, 프리셋 번호만 저장하도록 수정 로직 필요)
  - 퀴즈 생성 추가하기 버튼이 10개를 넘기면 보이지 않도록 추가(한 퀴즈당 최대 10개)

- 퀴즈 수정 페이지 생성
  - 선택된 퀴즈 프리셋 정보 불러오기
 
- 나의 퀴즈 페이지 생성
  - 로컬 스토리지에 저장된 퀴즈 프리셋을 목록으로 보여줌 (이후, 로컬 스토리지에 저장된 프리셋 핀 번호로 서버에서 조회하여 현재 서버에 저장된 값을 사용할 수 있도록 해야 함)
  - 각 프리셋별 시작하기 / 수정하기 / 삭제하기 버튼 노출
  - 시작하기 버튼을 눌렀을 때 게임 시작 모달 오픈
  - 삭제하기 버튼을 눌렀을 때 삭제 여부 재확인 후, 삭제 요청 api 호출
  - 수정하기 버튼을 눌렀을 때 수정 페이지로 이동
 
### 스크린샷
1. 나의 퀴즈 페이지
<img width="361" alt="image" src="https://github.com/NaYeongSeokGame/ImNayeoungSeokToo-client/assets/30384031/ae616412-737e-4bac-8019-a507ca64cff7">

2. 퀴즈 프리셋 수정 페이지
<img width="359" alt="image" src="https://github.com/NaYeongSeokGame/ImNayeoungSeokToo-client/assets/30384031/67142305-2cb5-4b43-9b5b-37d89423078d">
<img width="360" alt="image" src="https://github.com/NaYeongSeokGame/ImNayeoungSeokToo-client/assets/30384031/c86b16c4-b87c-4b48-97b9-2e29c4718720">


### 잔여 작업
- 퀴즈 생성 페이지, 퀴즈 수정 페이지가 동일한 형태이므로, 같은 컴포넌트를 사용하도록 수정 진행
- 현재 로컬 스토리지에 저장된 퀴즈가 유효한 퀴즈 프리셋인지 여부와, 이미지 url이 변경될 수 있으므로, 로컬 스토리지에 저장된 프리셋들의 번호로 서버에서 재조회하는 로직 필요




## Checklist

- [x] Code Review 요청
- [x] PR 제목 commit convention에 맞는지 확인
- [x] Label 설정
- [x] Jira 코드 리뷰 상태로 변경
